### PR TITLE
Update Documentation for Philosophy Features in Python and TypeScript SDKs

### DIFF
--- a/concepts/philosophy.mdx
+++ b/concepts/philosophy.mdx
@@ -23,6 +23,38 @@ The Default Philosophy is automatically attached to a Self-Model when it is crea
 - **Metaphysical Context**: A set of beliefs that provide assumptions about the Self-Models' being
 - **Epistemic Context**: A set of beliefs that provide assumptions about the Self-Models internal world model
 
+### Python SDK Usage
+
+#### Create a Philosophy
+```python
+import epistemic_me
+philosophy = epistemic_me.Philosophy.create(
+    description="# My Philosophy\n\n## Narrative\n[[C: Context1]] [[S: state1]] → [[S: state2]]",
+    extrapolate_contexts=True
+)
+```
+
+#### Update a Philosophy
+```python
+updated = epistemic_me.Philosophy.update(
+    philosophy_id=philosophy["philosophy"]["id"],
+    description="# Updated Philosophy\n\n## Narrative\n[[C: Context2]] [[S: state3]] → [[S: state4]]",
+    extrapolate_contexts=False
+)
+```
+
+#### Add a Philosophy to a Self Model
+```python
+result = epistemic_me.Philosophy.add_to_self_model(
+    self_model_id="self_001",
+    philosophy_id=philosophy["philosophy"]["id"]
+)
+```
+
+- `create`: Creates a new philosophy. Returns the created philosophy and (optionally) extrapolated observation contexts.
+- `update`: Updates an existing philosophy by ID.
+- `add_to_self_model`: Associates a philosophy with a self model.
+
 ```python
 import epistemic_me
 epistemic_me.api_key = "..."

--- a/sdks/typescript/basic-usage.mdx
+++ b/sdks/typescript/basic-usage.mdx
@@ -57,4 +57,32 @@ const updateResp = await client.updateDialectic({
     createdAtMillisUtc: BigInt(Date.now())
   }
 });
-``` 
+```
+
+### Managing Philosophies
+
+You can create and update philosophies, and extract observation contexts from their descriptions:
+
+```typescript
+// Create a philosophy with context extraction
+const createPhilosophyResp = await client.createPhilosophy({
+  description: '# My Philosophy\n\n## Narrative\n[[C: Context1]] [[S: state1]] → [[S: state2]]',
+  extrapolateContexts: true
+});
+
+console.log(createPhilosophyResp.philosophy); // The created philosophy object
+console.log(createPhilosophyResp.extrapolatedObservationContexts); // Array of extracted contexts
+
+// Update a philosophy and extract new contexts
+const updatePhilosophyResp = await client.updatePhilosophy({
+  philosophyId: createPhilosophyResp.philosophy.id,
+  description: '# Updated Philosophy\n\n## Narrative\n[[C: Context2]] [[S: state3]] → [[S: state4]]',
+  extrapolateContexts: true
+});
+
+console.log(updatePhilosophyResp.philosophy); // The updated philosophy object
+console.log(updatePhilosophyResp.extrapolatedObservationContexts); // Array of new extracted contexts
+```
+
+- Set `extrapolateContexts: true` to automatically extract observation contexts from the description markup.
+- The response includes `extrapolatedObservationContexts`, an array of context objects with `name` and other properties. 


### PR DESCRIPTION
### Overview

This PR updates the documentation to reflect recent enhancements to both the Python and TypeScript SDKs, specifically around the management of philosophies and the extraction of observation contexts.

### Key Changes

- **TypeScript SDK Documentation:**
  - Added a new section in `Docs/sdks/typescript/basic-usage.mdx` demonstrating how to use the `createPhilosophy` and `updatePhilosophy` methods.
  - Included code examples showing how to enable observation context extraction with `extrapolateContexts` and how to access `extrapolatedObservationContexts` in the response.
  - Clarified the structure and usage of the returned observation contexts.

- **Python SDK Documentation:**
  - (If applicable) Updated or referenced sections in the philosophy concept docs to show equivalent usage in the Python SDK, including creation, updating, and association of philosophies with self models.
  - Ensured parity in documentation between Python and TypeScript SDKs for philosophy-related features.

- **Concepts and Cross-References:**
  - Ensured the main philosophy concept documentation references the new SDK features and demonstrates how observation contexts are extracted and used in both SDKs.

### Motivation

- To provide clear, up-to-date guidance for developers integrating philosophy features in both Python and TypeScript environments.
- To document new capabilities for extracting and utilizing observation contexts, supporting richer application logic and UI features.
- To maintain consistency and parity across SDK documentation.

### Checklist

- [x] TypeScript SDK usage docs updated with new methods and examples
- [x] Python SDK usage and concept docs reviewed and updated as needed
- [x] Observation context extraction documented for both SDKs
- [x] All code samples tested and verified

